### PR TITLE
Add `size` parameter - #4

### DIFF
--- a/gravify/__init__.py
+++ b/gravify/__init__.py
@@ -9,25 +9,27 @@ sentry_sdk.init("https://d1a3441649e64a96b52c441233c47f26@sentry.io/1763873")  #
 
 class Gravatar():
 
-    def __init__(self, email, verify_email=True, default_image=None):
+    def __init__(self, email, verify_email=True, default_image=None, size=None):
         if verify_email:
             if not validate_email(email):
                 raise Exception("Invalid email address")
 
         self.email = email
         self.default_image = default_image
+        self.size = size
 
     @property
     def url(self):
-        params = {}
+        params = {
+            "s": self.size,
+            "d": self.default_image
+        }
 
-        if self.default_image is not None:
-            params["d"] = self.default_image
+        url_params = urllib.parse.urlencode({k: v for k, v in params.items() if v is not None})
 
-        _url = "https://www.gravatar.com/avatar/" + self.hash
-        if params:
-            return _url + "?{}".format(urllib.parse.urlencode(params))
-        return _url
+        _url = f"https://www.gravatar.com/avatar/{self.hash}"
+
+        return f"{_url}?{url_params}" if url_params else _url
 
     @property
     def unsecure_url(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,6 +24,11 @@ class TestMain(unittest.TestCase):
             gravify.Gravatar("bensoyka@icloud.com", default_image=None).url,
             "https://www.gravatar.com/avatar/7246821a7bf0b1b37794b39cb08ee052")
 
+    def test_with_size_param(self):
+        self.assertEqual(
+            gravify.Gravatar("bensoyka@icloud.com", default_image=None, size=200).url,
+            "https://www.gravatar.com/avatar/7246821a7bf0b1b37794b39cb08ee052?s=200")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds the `size` parameter to the Gravify lib and refactors some of the code in the `url` property. There is no need to validate the size input since values outside the range or invalid input like strings default to 1px or 2048px in the Gravatar API.

- Add `size` parameter
- Small refactoring of the `url` property
- Add test to validate