### PR TITLE
Strip spaces

### DIFF
--- a/gravify/__init__.py
+++ b/gravify/__init__.py
@@ -38,7 +38,7 @@ class Gravatar():
 
     @property
     def hash(self):
-        return hashlib.md5(self.email.strip(" ").encode("utf-8").lower()).hexdigest()
+        return hashlib.md5(self.email.strip().encode("utf-8").lower()).hexdigest()
 
     @property
     def file(self):

--- a/gravify/__init__.py
+++ b/gravify/__init__.py
@@ -38,7 +38,7 @@ class Gravatar():
 
     @property
     def hash(self):
-        return hashlib.md5(self.email.encode("utf-8").lower()).hexdigest()
+        return hashlib.md5(self.email.replace(" ", "").encode("utf-8").lower()).hexdigest()
 
     @property
     def file(self):

--- a/gravify/__init__.py
+++ b/gravify/__init__.py
@@ -38,7 +38,7 @@ class Gravatar():
 
     @property
     def hash(self):
-        return hashlib.md5(self.email.replace(" ", "").encode("utf-8").lower()).hexdigest()
+        return hashlib.md5(self.email.strip(" ").encode("utf-8").lower()).hexdigest()
 
     @property
     def file(self):

--- a/gravify/__init__.py
+++ b/gravify/__init__.py
@@ -15,7 +15,7 @@ class Gravatar():
             if not validate_email(email):
                 raise Exception("Invalid email address")
 
-        self.email = email
+        self.email = email.strip().lower()
         self.default_image = default_image
         self.size = size
 
@@ -38,7 +38,7 @@ class Gravatar():
 
     @property
     def hash(self):
-        return hashlib.md5(self.email.strip().encode("utf-8").lower()).hexdigest()
+        return hashlib.md5(self.email.encode("utf-8")).hexdigest()
 
     @property
     def file(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,15 @@ class TestMain(unittest.TestCase):
     def test_hash(self):
         self.assertEqual(gravify.Gravatar("bensoyka@icloud.com").hash, "7246821a7bf0b1b37794b39cb08ee052")
 
+    def test_hash_whitespace(self):
+        self.assertEqual(gravify.Gravatar("   \tbensoyka@icloud.com\n").hash, "7246821a7bf0b1b37794b39cb08ee052")
+
+    def test_hash_inner_spaces(self):
+        self.assertEqual(gravify.Gravatar('"ben soyka"@icloud.com').hash, "5d09bd0d26efc0871a3977aa55fb3f9c")
+
+    def test_hash_to_lowercase(self):
+        self.assertEqual(gravify.Gravatar("bEnSoYkA@iClOuD.cOm").hash, "7246821a7bf0b1b37794b39cb08ee052")
+
     def test_default_identicon(self):
         self.assertEqual(gravify.Gravatar("bensoyka@icloud.com", default_image="identicon").url,
                          "https://www.gravatar.com/avatar/7246821a7bf0b1b37794b39cb08ee052?d=identicon")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,9 +18,6 @@ class TestMain(unittest.TestCase):
     def test_hash_whitespace(self):
         self.assertEqual(gravify.Gravatar("   \tbensoyka@icloud.com\n").hash, "7246821a7bf0b1b37794b39cb08ee052")
 
-    def test_hash_inner_spaces(self):
-        self.assertEqual(gravify.Gravatar('"ben soyka"@icloud.com').hash, "5d09bd0d26efc0871a3977aa55fb3f9c")
-
     def test_hash_to_lowercase(self):
         self.assertEqual(gravify.Gravatar("bEnSoYkA@iClOuD.cOm").hash, "7246821a7bf0b1b37794b39cb08ee052")
 


### PR DESCRIPTION
Hello, hope your day is going well! I think this fixes the issue with leading and trailing spaces in an email before hashing. I elected not to modify the stored email address, just to strip the spaces when hashing. If modifying the email value is desired let me know and I can implement that.